### PR TITLE
Get length of bytes & fixed bug on unpacking

### DIFF
--- a/test/unpack_i32_tb.v
+++ b/test/unpack_i32_tb.v
@@ -5,8 +5,9 @@ module unpack_i32_tb ();
 
   reg [7:0] i0, i1, i2, i3, i4;
   wire [31:0] o;
+  wire [ 2:0] len;
 
-  unpack_i32 DUT(i0, i1, i2, i3, i4, o);
+  unpack_i32 DUT(i0, i1, i2, i3, i4, o, len);
 
   initial begin
     $dumpfile("unpack_i32_tb.vcd");
@@ -18,7 +19,8 @@ module unpack_i32_tb ();
     i3 = 0;
     i4 = 0;
     #1
-    `assert(o , 0);
+    `assert(o  , 0);
+    `assert(len, 1);
 
     i0 = 8'h9b;
     i1 = 8'hf1;
@@ -26,7 +28,8 @@ module unpack_i32_tb ();
     i3 = 0;
     i4 = 0;
     #1
-    `assert(o , -624485);
+    `assert(o  , -624485);
+    `assert(len, 3);
 
     $display("ok");
     $finish;

--- a/test/unpack_u32_tb.v
+++ b/test/unpack_u32_tb.v
@@ -5,8 +5,9 @@ module unpack_u32_tb ();
 
   reg [7:0] i0, i1, i2, i3, i4;
   wire [31:0] o;
+  wire [ 2:0] len;
 
-  unpack_u32 DUT(i0, i1, i2, i3, i4, o);
+  unpack_u32 DUT(i0, i1, i2, i3, i4, o, len);
 
   initial begin
     $dumpfile("unpack_u32_tb.vcd");
@@ -18,7 +19,8 @@ module unpack_u32_tb ();
     i3 = 0;
     i4 = 0;
     #1
-    `assert(o , 0);
+    `assert(o  , 0);
+    `assert(len, 1);
 
     i0 = 8'he5;
     i1 = 8'h8e;
@@ -26,7 +28,8 @@ module unpack_u32_tb ();
     i3 = 0;
     i4 = 0;
     #1
-    `assert(o , 624485);
+    `assert(o  , 624485);
+    `assert(len, 3);
 
     $display("ok");
     $finish;

--- a/test/unpack_u32_tb.v
+++ b/test/unpack_u32_tb.v
@@ -22,6 +22,15 @@ module unpack_u32_tb ();
     `assert(o  , 0);
     `assert(len, 1);
 
+    i0 = 42;
+    i1 = 0;
+    i2 = 0;
+    i3 = 0;
+    i4 = 0;
+    #1
+    `assert(o  , 42);
+    `assert(len, 1);
+
     i0 = 8'he5;
     i1 = 8'h8e;
     i2 = 8'h26;

--- a/unpack_i32.v
+++ b/unpack_i32.v
@@ -1,6 +1,7 @@
 module unpack_i32 (
   input [7:0] i0, i1, i2, i3, i4,
-  output logic [31:0] o
+  output logic [31:0] o,
+  output wire  [ 2:0] len
 );
 
   wire[31:0] u32_output;
@@ -8,7 +9,7 @@ module unpack_i32 (
   logic [4:0] gl, ub, ho, sb;
   logic [6:0] l0, l1, l2, l3, l4;
 
-  unpack_u32 u32(i0, i1, i2, i3, i4, u32_output);
+  unpack_u32 u32(i0, i1, i2, i3, i4, u32_output, len);
 
   always @* begin
     // Glue bits

--- a/unpack_u32.v
+++ b/unpack_u32.v
@@ -5,7 +5,8 @@ module unpack_u32 (
 );
 
 // i = $.wire()
-logic [4:0] gl, dc, ho;
+logic [4:0] gl, ho;
+logic [4:1] dc;
 logic [6:0] c0, c1, c2, c3, c4;
 logic [6:0] k0, k1, k2, k3, k4;
 
@@ -23,19 +24,17 @@ always @* begin
   c3 = i3[6:0];
   c4 = i4[6:0];
   // dc = gl.expand.up()
-  dc[0] = gl[0];
-  dc[1] = gl[0] | gl[1];
-  dc[2] = gl[0] | gl[1] | gl[2];
-  dc[3] = gl[0] | gl[1] | gl[2] | gl[3];
-  dc[4] = gl[0] | gl[1] | gl[2] | gl[3] | gl[4];
+  dc[1] = gl[0];
+  dc[2] = gl[0] | gl[1];
+  dc[3] = gl[0] | gl[1] | gl[2];
+  dc[4] = gl[0] | gl[1] | gl[2] | gl[3];
   // k = c.overwrite(dc, 0)
-  k0 = dc[0] ? c0 : 7'b0;
   k1 = dc[1] ? c1 : 7'b0;
   k2 = dc[2] ? c2 : 7'b0;
   k3 = dc[3] ? c3 : 7'b0;
   k4 = dc[4] ? c4 : 7'b0;
   // o = k.glue()
-  o = {k4, k3, k2, k1, k0};
+  o = {k4, k3, k2, k1, c0};
 
   // Get high order byte
   ho[0] = !gl[0];

--- a/unpack_u32.v
+++ b/unpack_u32.v
@@ -1,11 +1,11 @@
 module unpack_u32 (
   input [7:0] i0, i1, i2, i3, i4,
-  output logic [31:0] o
+  output logic [31:0] o,
+  output logic [ 2:0] len  // TODO make zero-based index instead of off-by-one
 );
 
 // i = $.wire()
-logic [4:0] gl;
-logic [4:0] dc;
+logic [4:0] gl, dc, ho;
 logic [6:0] c0, c1, c2, c3, c4;
 logic [6:0] k0, k1, k2, k3, k4;
 
@@ -36,6 +36,17 @@ always @* begin
   k4 = dc[4] ? c4 : 7'b0;
   // o = k.glue()
   o = {k4, k3, k2, k1, k0};
+
+  // Get high order byte
+  ho[0] = !gl[0];
+  ho[1] = !gl[1] & gl[0];
+  ho[2] = !gl[2] & gl[1];
+  ho[3] = !gl[3] & gl[2];
+  ho[4] = !gl[4] & gl[3];
+
+  len[0] = ho[0] |         ho[2] |         ho[4];
+  len[1] =         ho[1] | ho[2]                ;
+  len[2] =                         ho[3] | ho[4];
 end
 
 endmodule


### PR DESCRIPTION
The bug was about not considering the case of numbers stored on a single byte, we definitely need to add more tests cases. I understand your point of using verilator to build some Node.js bindings and doing the tests in Node.js, is a cool idea, but by the moment using the Makefile is just enought. I would be cool if you start a Verilog binding framework project, but I would do as an independent one.

The length of the bytes is needed to know exactly how much data I inserted. I put it as an aditional parameter, but since is a somewhat independent, don't know if I should put it on its own isolated module to don't waste transistors... what do you think?

By the way, it's getting a bit complicated to convert the code to use `generate`, that's a shame... :-( Do you have more knowledges about Verilog?